### PR TITLE
APIエンドポイントの型を修正し、フロントを整形

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -3,9 +3,8 @@ import { cors } from 'hono/cors'
 import tasks from '@/routes/tasks'
 
 const app = new Hono()
-app.use('/task/*', cors())
-
-app.route('/task', tasks)
+  .use('/task/*', cors())
+  .route('/task', tasks)
 
 export default app
 export type AppType = typeof app

--- a/backend/src/repository/taskRepository.test.ts
+++ b/backend/src/repository/taskRepository.test.ts
@@ -1,6 +1,6 @@
 import { ulid } from 'ulid'
 import {
-  beforeAll, describe, expect, test,
+  assert, beforeAll, describe, expect, test,
 } from 'vitest'
 import {
   deleteTask, getTask, listTasks, saveTask,
@@ -29,7 +29,8 @@ describe('単一項目のCRUD', () => {
   })
 
   test('既存の項目を更新できること', () => {
-    const storedTask = getTask(storedTaskId)!
+    const storedTask = getTask(storedTaskId)
+    assert(storedTask !== undefined)
     const updated: Task = {
       ...storedTask,
       title: 'Updated',
@@ -43,7 +44,8 @@ describe('単一項目のCRUD', () => {
   })
 
   test('項目を削除できること', () => {
-    const deletedTask = deleteTask(storedTaskId)!
+    const deletedTask = deleteTask(storedTaskId)
+    assert(deletedTask !== undefined)
     expect(getTask(deletedTask.id)).toBeUndefined()
   })
 })

--- a/backend/src/routes/tasks.ts
+++ b/backend/src/routes/tasks.ts
@@ -56,7 +56,10 @@ const app = new Hono()
       const id = c.req.valid('param').id
       const storedTask = getTask(id)
       if (storedTask === undefined) {
-        return c.notFound()
+        return c.json({
+          error: `no such task with id ${id}`,
+          ok: false,
+        }, 404)
       }
       return c.json(storedTask)
     },
@@ -76,12 +79,18 @@ const app = new Hono()
       // paramとjsonとを同時にvalidateできないか?
       const id = z.string().ulid().safeParse(c.req.param('id')).data
       if (id === undefined) {
-        return c.notFound()
+        return c.json({
+          error: 'Please specify task id',
+          ok: false,
+        }, 400)
       }
 
       const storedTask = getTask(id)
       if (storedTask === undefined) {
-        return c.notFound()
+        return c.json({
+          error: `no such task with id ${id}`,
+          ok: false,
+        }, 404)
       }
 
       const taskData = c.req.valid('json')
@@ -102,7 +111,10 @@ const app = new Hono()
     (c) => {
       const id = c.req.valid('param').id
       if (getTask(id) === undefined) {
-        return c.notFound()
+        return c.json({
+          error: `no such task with id ${id}`,
+          ok: false,
+        }, 404)
       }
       const deletedTask = deleteTask(id)
       return c.json(deletedTask, 200)

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,35 +1,70 @@
 <template>
   <h2>Hono RPC sample</h2>
-  <div>registered tasks</div>
-  <ul>
-    <li
-      v-for="task in tasks"
-      :key="task.id"
-    >
-      {{ task.id }} {{ task.title }} (due: {{ task.limit }}
-      priority: {{ task.priority }})
-    </li>
-  </ul>
+
+  <TaskRegisterForm @submit="onSubmit" />
+
+  <hr>
+
+  <TaskListComponent
+    :tasks="tasks"
+    @show-detail="onClickDetail"
+    @delete="onClickDelete"
+  />
 </template>
 
 <script setup lang="ts">
 import { onMounted, ref } from 'vue'
 import type { TaskListItem } from '@backend/repository/taskRepository'
+import type { Task } from '@backend/resource/task'
 import { client } from './client'
+import TaskListComponent from './TaskListComponent.vue'
+import TaskRegisterForm from './TaskRegisterForm.vue'
 
 const tasks = ref<TaskListItem[]>([])
 
 onMounted(async () => {
+  await loadItem()
+})
+
+const loadItem = async () => {
   // TODO: 双方プリミティブ型でやりとりした方がよいのでは?
   const tasksData = await (await client.task.$get({ query: {} })).json()
-  tasks.value = tasksData.map(({
-    id, title, limit, priority,
-  }) => ({
-    id,
-    title,
-    priority,
-    limit: new Date(limit),
+  tasks.value = tasksData.map(task => ({
+    ...task,
+    limit: new Date(task.limit),
   }))
-})
+}
+
+// MARK: - Event handlers
+
+const onClickDetail = async (id: TaskListItem['id']) => {
+  const response = await client.task[':id'].$get({ param: { id } })
+  if (!response.ok) {
+    alert('Failed to get details of task')
+    return
+  }
+  const task = await response.json()
+  alert(task.description)
+}
+
+const onClickDelete = async (id: TaskListItem['id']) => {
+  const response = await client.task[':id'].$delete({ param: { id } })
+  if (!response.ok) {
+    alert('Failed to delete task')
+    return
+  }
+
+  await loadItem()
+}
+
+const onSubmit = async (task: Omit<Task, 'id'>) => {
+  const response = await client.task.$post({ json: task })
+  if (!response.ok) {
+    alert('Failed to register new task')
+    return
+  }
+
+  await loadItem()
+}
 
 </script>

--- a/frontend/src/TaskListComponent.vue
+++ b/frontend/src/TaskListComponent.vue
@@ -1,0 +1,38 @@
+<template>
+  <h2>Registered tasks</h2>
+  <ul>
+    <li
+      v-for="task in props.tasks"
+      :key="task.id"
+    >
+      <ul>
+        <li>title: {{ task.title }}</li>
+        <li>priority: {{ task.priority }}</li>
+        <li>due: {{ task.limit.toISOString() }}</li>
+        <li>
+          <button @click="emits('showDetail', task.id)">
+            show details
+          </button>
+        </li>
+        <li>
+          <button @click="emits('delete', task.id)">
+            delete
+          </button>
+        </li>
+      </ul>
+    </li>
+  </ul>
+</template>
+
+<script setup lang="ts">
+import type { TaskListItem } from '@backend/repository/taskRepository'
+
+const props = defineProps<{ tasks: TaskListItem[] }>()
+const emits = defineEmits<{
+  (
+    operation: 'showDetail' | 'delete',
+    id: TaskListItem['id']
+  ): void
+}>()
+
+</script>

--- a/frontend/src/TaskRegisterForm.vue
+++ b/frontend/src/TaskRegisterForm.vue
@@ -1,0 +1,69 @@
+<template>
+  <h2>Register new task</h2>
+
+  <form @submit.prevent="emits('submit', newTask)">
+    <label for="title">タスク名</label>
+    <input
+      id="title"
+      v-model="newTask.title"
+      type="text"
+    >
+
+    <label for="priority">優先度</label>
+    <select
+      id="priority"
+      v-model="newTask.priority"
+    >
+      <option value="high">
+        高
+      </option>
+      <option
+        value="middle"
+        selected
+      >
+        中
+      </option>
+      <option value="low">
+        低
+      </option>
+    </select>
+
+    <label for="description">説明</label>
+    <input
+      id="description"
+      v-model="newTask.description"
+      type="text"
+    >
+
+    <label for="limit">期日</label>
+    <input
+      id="limit"
+      v-model="limitDateString"
+      type="date"
+    >
+
+    <button type="submit">
+      追加
+    </button>
+  </form>
+</template>
+
+<script setup lang="ts">
+import type { Task } from '@backend/resource/task'
+import { ref, watch } from 'vue'
+
+const emits = defineEmits<{ (e: 'submit', task: Omit<Task, 'id'>): void }>()
+
+const newTask = ref<Omit<Task, 'id'>>({
+  title: '',
+  priority: 'middle',
+  limit: new Date(),
+  description: '',
+})
+
+const limitDateString = ref<string>('')
+watch(limitDateString, () => {
+  newTask.value.limit = new Date(limitDateString.value)
+})
+
+</script>


### PR DESCRIPTION
Fixes: #3

フロントで正しくclientを構成できるようエンドポイントの定義を修正
ついでにコンポーネント分割と基本的なCRUDの実装