### PR TITLE
バックエンドのデプロイを構成

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,28 @@
+name: deploy
+on:
+  workflow_dispatch:
+  push:
+    branches: release
+  pull_request:
+    branches: master
+    types: closed
+
+jobs:
+  deploy-backend:
+    if: github.event_name != 'pull_request' || (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: install
+        run: npm i
+
+      - name: deploy
+        env:
+          CF_ACCOUNT_ID: ${{ secrets.CF_ACCOUNT_ID }}
+          CF_API_TOKEN: ${{ secrets.CF_API_TOKEN }}
+        run: npm run -w backend deploy

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,7 +3,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "dev": "wrangler dev",
+    "dev": "wrangler dev --port=3000",
     "test": "vitest",
     "deploy": "wrangler deploy",
     "db:init": "wrangler d1 execute hono-rpc-sample-backend-db --local --file='src/infrastructure/migrations/0000-init.sql'",

--- a/backend/package.json
+++ b/backend/package.json
@@ -3,11 +3,11 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
-    "dev": "wrangler dev --port=3000",
+    "dev": "wrangler --env=development dev --port=3000",
     "test": "vitest",
-    "deploy": "wrangler deploy",
-    "db:init": "wrangler d1 execute hono-rpc-sample-backend-db --local --file='src/infrastructure/migrations/0000-init.sql'",
-    "db:init:remote": "wrangler d1 execute hono-rpc-sample-backend-db --remote --file='src/infrastructure/migrations/0000-init.sql'"
+    "deploy": "wrangler --env=production deploy",
+    "db:init": "wrangler --env=development d1 execute hono-rpc-sample-backend-db --local --file='src/infrastructure/migrations/0000-init.sql'",
+    "db:init:remote": "wrangler --env=production d1 execute hono-rpc-sample-backend-db --remote --file='src/infrastructure/migrations/0000-init.sql'"
   },
   "dependencies": {
     "hono": "^4.6.15",

--- a/backend/src/env.d.ts
+++ b/backend/src/env.d.ts
@@ -1,4 +1,7 @@
-interface Env { D1: D1Database }
+interface Env {
+  D1: D1Database
+  FRONTEND_URL: string | string[]
+}
 
 declare module 'cloudflare:test' {
   interface ProvidedEnv extends Env { TEST_MIGRATIONS: D1Migration[] }

--- a/backend/src/presentations/index.ts
+++ b/backend/src/presentations/index.ts
@@ -1,9 +1,16 @@
 import { Hono } from 'hono'
 import { cors } from 'hono/cors'
+import { createMiddleware } from 'hono/factory'
 import tasks from '@/presentations/tasks'
 
 const app = new Hono()
-  .use('/task/*', cors())
+  .use('/task/*', createMiddleware<{ Bindings: Env }>(async (c, next) => {
+    const corsMiddleware = cors({
+      origin: c.env.FRONTEND_URL,
+      credentials: true,
+    })
+    return corsMiddleware(c, next)
+  }))
   .route('/task', tasks)
 
 export default app

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -2,11 +2,33 @@ name = "hono-rpc-sample-backend"
 compatibility_date = "2025-01-28"
 compatibility_flags = [ "nodejs_compat" ]
 main = "./src/presentations/index.ts"
+preview_urls = false
+workers_dev = false
 
 [observability]
 enabled = true
 
-[[d1_databases]]
+# local
+[env.development.vars]
+FRONTEND_URL = "http://localhost:3002"
+
+[[env.development.d1_databases]]
+binding = "D1"
+database_name = "hono-rpc-sample-backend-db"
+database_id = "f1f9bbae-f053-4de7-a05d-0462b76185fe"
+
+# Cloudflare
+[env.production.vars]
+FRONTEND_URL = [
+  "https://hono-rpc-sample.enchan.me",
+  "https://master.hono-rpc-sample-frontend.pages.dev"
+]
+
+[[env.production.routes]]
+pattern = "api.hono-rpc-sample.enchan.me"
+custom_domain = true
+
+[[env.production.d1_databases]]
 binding = "D1"
 database_name = "hono-rpc-sample-backend-db"
 database_id = "f1f9bbae-f053-4de7-a05d-0462b76185fe"

--- a/frontend/.env.production
+++ b/frontend/.env.production
@@ -1,0 +1,1 @@
+VITE_BACKEND_URL="https://api.hono-rpc-sample.enchan.me"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,9 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "build": "vite build",
-    "dev": "vite dev --port=3002"
+    "dev": "vite dev --port=3002",
+    "predeploy": "npm run build",
+    "deploy": "wrangler pages deploy"
   },
   "dependencies": {
     "dayjs": "^1.11.13",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "build": "vite build",
-    "dev": "vite dev"
+    "dev": "vite dev --port=3002"
   },
   "dependencies": {
     "dayjs": "^1.11.13",

--- a/frontend/src/repositories/client.ts
+++ b/frontend/src/repositories/client.ts
@@ -4,4 +4,4 @@ import type { AppType } from '@routes/index'
 import { hc } from 'hono/client'
 
 const env = import.meta.env
-export const client = hc<AppType>(env.VITE_BACKEND_URL)
+export const client = hc<AppType>(env.VITE_BACKEND_URL, { init: { credentials: 'include' } })

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,7 @@
     "verbatimModuleSyntax": true,
     "paths": {
       "@/*": ["./src/*"],
-      "@routes/*": ["../backend/src/routes/*"]
+      "@routes/*": ["../backend/src/presentations/*"]
     },
     "types": [
       "unplugin-vue-router/client"

--- a/frontend/wrangler.toml
+++ b/frontend/wrangler.toml
@@ -1,0 +1,3 @@
+name = "hono-rpc-sample-frontend"
+pages_build_output_dir = "./dist"
+compatibility_date = "2025-01-28"


### PR DESCRIPTION
Fixes: #16

インフラ再構成

一旦バックエンドのデプロイだけ構成した

- **chore: #16 set dev server ports**
- **fix: backend relation at tsconfig.json**
- **feat: #16 configure frontend as CF Pages**
- **feat: #16 configure CORS strictly**
- **chore: #16 modify setup script**
- **feat: #16 configure deploy script for backend**
