### PR TITLE
無限スクロールを想定したメソッドの追加

### DIFF
--- a/backend/src/infrastructure/repositories/taskRepository.ts
+++ b/backend/src/infrastructure/repositories/taskRepository.ts
@@ -87,7 +87,7 @@ const listTasks = (db: D1Database): TaskRepository['listTasks'] => async (
     ORDER BY ${sortBy} ${order === 'asc' ? 'ASC' : 'DESC'}
     ${sortBy !== 'id' ? ', id ASC' : ''}
     LIMIT ?
-    ${offset ? 'OFFSET ?' : ''}
+    ${offset !== undefined ? 'OFFSET ?' : ''}
   `
 
   const stmt = db.prepare(query)

--- a/backend/src/presentations/tasks.ts
+++ b/backend/src/presentations/tasks.ts
@@ -26,8 +26,8 @@ const app = new Hono<{ Bindings: Env }>()
       z.object({
         key: z.enum(['id', 'due', 'priority']).default('due'),
         order: z.enum(['asc', 'desc']).default('desc'),
-        limit: z.number().optional().default(30),
-        offset: z.number().optional(),
+        limit: z.string().pipe(z.coerce.number().min(1).int()).default('20'),
+        offset: z.string().pipe(z.coerce.number().min(0).int()).optional(),
       }),
     ),
     async (c) => {

--- a/frontend/src/pages/tasks/index.vue
+++ b/frontend/src/pages/tasks/index.vue
@@ -25,6 +25,16 @@
       @detail="onClickDetail"
       @remove="remove"
     />
+    <button
+      v-if="hasNext"
+      :disabled="isLoading"
+      @click="next"
+    >
+      load more
+    </button>
+    <template v-else>
+      -- last item --
+    </template>
   </template>
   <hr>
   <button @click="onClickAdd">
@@ -43,15 +53,19 @@ const router = useRouter()
 
 const key = ref<'id' | 'due' | 'priority'>('id')
 const order = ref <'asc' | 'desc'>('desc')
+const itemPerPage = ref(20)
 
 const {
   tasks,
   isLoading,
   error,
+  next,
+  hasNext,
   remove,
 } = useTaskList({
   key,
   order,
+  itemPerPage,
 })
 
 // MARK: - Event handlers

--- a/frontend/src/pages/tasks/index.vue
+++ b/frontend/src/pages/tasks/index.vue
@@ -9,6 +9,23 @@
     <button @click="onClickKey">
       key: {{ key }}
     </button>
+
+    <label for="item_per_page">Items per page:</label>
+    <select
+      id="item_per_page"
+      v-model="itemPerPage"
+    >
+      <template
+        v-for="count in itemCountSelections"
+        :key="count"
+      >
+        <option
+          :value="count"
+        >
+          {{ count }}
+        </option>
+      </template>
+    </select>
   </div>
 
   <template v-if="isLoading">
@@ -45,6 +62,7 @@
 <script setup lang="ts">
 import { useRouter } from 'vue-router'
 import { ref } from 'vue'
+import type { Ref } from 'vue'
 import type { TaskListItem } from '@/entities/task'
 import TaskList from '@/components/TaskList.vue'
 import { useTaskList } from '@/composables/useTaskList'
@@ -53,7 +71,9 @@ const router = useRouter()
 
 const key = ref<'id' | 'due' | 'priority'>('id')
 const order = ref <'asc' | 'desc'>('desc')
-const itemPerPage = ref(20)
+
+const itemCountSelections = [5, 10, 20, 50] as const
+const itemPerPage: Ref<(typeof itemCountSelections)[number]> = ref(20)
 
 const {
   tasks,

--- a/frontend/src/repositories/taskRepository.ts
+++ b/frontend/src/repositories/taskRepository.ts
@@ -7,8 +7,16 @@ import type { Task, TaskListItem } from '@/entities/task'
 export const listTask = async (query: {
   key?: 'id' | 'due' | 'priority'
   order?: 'desc' | 'asc'
+  limit?: number
+  offset?: number
 }): Promise<TaskListItem[]> => {
-  const response = await client.task.$get({ query })
+  const response = await client.task.$get({
+    query: {
+      ...query,
+      limit: query.limit?.toString(),
+      offset: query.offset?.toString(),
+    },
+  })
   const taskDatas = await response.json()
   const tasks: TaskListItem[] = taskDatas.map(task => ({
     ...task,


### PR DESCRIPTION
Fixes: #21

無限スクロールを想定し、 `next`, `reload` などのメソッドを追加した。

- **fix: #21 backend request types**
- **feat: #21 無限スクロール用の関数を提供**
- **feat: #21 アイテム数セレクタを追加**
