### PR TITLE
開発サーバの設定変更

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.dev.vars
 .wrangler
 
 # Created by https://www.toptal.com/developers/gitignore/api/node,typescript

--- a/README.md
+++ b/README.md
@@ -1,8 +1,62 @@
 # Try RPC feature of Hono
 
+HonoとCloudflareでいい感じのWebAppを作ってみるサンプル
+
 ## Overview
 
-[Hono](https://hono.dev/) のRPCを試してみる
+Tech stack:
+
+- frontend
+  - implementation
+    - Vue 3
+    - Vuetify
+    - vite
+    - Hono
+  - infrastructure
+    - Cloudflare Pages
+- backend
+  - implementation
+    - Hono
+  - infrastructure
+    - Cloudflare Workers
+    - Cloudflare D1
+
+## Usage
+
+### The easiest way: VSCode tasks
+
+1. open command pallete
+2. select `Tasks: Run Task`
+    1. choose `frontend server`
+    2. open another shell and choose `backend server`
+
+### Manual setup
+
+If you want to use non-default (frontend:5173, backend:8787) port, you can boot server manually.
+
+For example:
+
+- frontend: 60001
+- backend: 60002
+
+1. configure backend
+    1. create `backend/.dev.vars` (it'll be git-ignored):
+       ```ini
+       CORS_ALLOW_ORIGINS = "http://localhost:60001"
+       ```
+    1. boot server:
+       ```sh
+       npm run -w backend dev -- --port 60002
+       ```
+1. configure frontend
+    1. create `frontend/.env.development.local` (it'll be git-ignored):
+       ```ini
+       VITE_BACKEND_URL="http://localhost:60002"
+       ```
+    1. boot server:
+       ```sh
+       npm run -w frontend dev -- --port 60001
+       ```
 
 ## License
 

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,7 +4,7 @@
     "lint": "eslint",
     "lint:fix": "eslint --fix",
     "build": "tsc",
-    "dev": "wrangler --env=development dev --port=3000",
+    "dev": "wrangler --env=development dev",
     "test": "vitest",
     "predeploy": "npm run build",
     "deploy": "wrangler --env=production deploy",

--- a/backend/src/env.d.ts
+++ b/backend/src/env.d.ts
@@ -1,6 +1,6 @@
 interface Env {
   D1: D1Database
-  FRONTEND_URL: string | string[]
+  CORS_ALLOW_ORIGINS: string | string[]
 }
 
 declare module 'cloudflare:test' {

--- a/backend/src/presentations/index.ts
+++ b/backend/src/presentations/index.ts
@@ -6,7 +6,7 @@ import tasks from '@/presentations/tasks'
 const app = new Hono()
   .use('/task/*', createMiddleware<{ Bindings: Env }>(async (c, next) => {
     const corsMiddleware = cors({
-      origin: c.env.FRONTEND_URL,
+      origin: c.env.CORS_ALLOW_ORIGINS,
       credentials: true,
     })
     return corsMiddleware(c, next)

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -10,7 +10,7 @@ enabled = true
 
 # local
 [env.development.vars]
-CORS_ALLOW_ORIGINS = "*"
+CORS_ALLOW_ORIGINS = "http://localhost:5173"
 
 [[env.development.d1_databases]]
 binding = "D1"

--- a/backend/wrangler.toml
+++ b/backend/wrangler.toml
@@ -10,7 +10,7 @@ enabled = true
 
 # local
 [env.development.vars]
-FRONTEND_URL = "http://localhost:3002"
+CORS_ALLOW_ORIGINS = "*"
 
 [[env.development.d1_databases]]
 binding = "D1"
@@ -19,7 +19,7 @@ database_id = "f1f9bbae-f053-4de7-a05d-0462b76185fe"
 
 # Cloudflare
 [env.production.vars]
-FRONTEND_URL = [
+CORS_ALLOW_ORIGINS = [
   "https://hono-rpc-sample.enchan.me",
   "https://master.hono-rpc-sample-frontend.pages.dev"
 ]

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,1 +1,1 @@
-VITE_BACKEND_URL="http://localhost:3000"
+VITE_BACKEND_URL="http://localhost:8787"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
     "lint:fix": "eslint --fix",
     "prebuild": "npm run -w backend build",
     "build": "npx vue-tsc && vite build",
-    "dev": "vite dev --port=3002",
+    "dev": "vite dev",
     "predeploy": "npm run build",
     "deploy": "wrangler pages deploy"
   },


### PR DESCRIPTION
Fixes: #23

開発サーバのポートを自由に設定できるようにしました。設定方法はREADMEにまとめています。

- **chore: #23 フロント・バックともにデフォルトポートで起動するよう変更**
- **chore: #23 CORS変数をリネーム、ローカル環境ではすべてのオリジンからの接続を受け付けるよう変更**
- **chore: #23 ローカルのCORS-Origin:\* をやめ, フロントのバックエンドURLをデフォルトポートのそれに変更**
- **chore: #23 README**
