### PR TITLE
フロントエンドのリポジトリにResultを導入

### DIFF
--- a/backend/src/presentations/tasks.test.ts
+++ b/backend/src/presentations/tasks.test.ts
@@ -95,6 +95,14 @@ describe('単一項目の操作', () => {
         ...input,
       })
     })
+
+    test('存在しない項目は更新できないこと', async () => {
+      const response = await client[':id'].$put({
+        json: {},
+        param: { id: 'INVALID' },
+      })
+      expect(response.ok).toBeFalsy()
+    })
   })
 
   describe('DELETE /task/:id', () => {

--- a/backend/src/presentations/tasks.ts
+++ b/backend/src/presentations/tasks.ts
@@ -96,6 +96,12 @@ const app = new Hono<{ Bindings: Env }>()
       const taskData = c.req.valid('json')
 
       const updateResult = await c.var.usecase.updateTask(id, taskData)
+      if (updateResult === undefined) {
+        return c.json({
+          error: `no such task with id ${id}`,
+          ok: false,
+        }, 404)
+      }
       return c.json(updateResult, 200)
     },
   )

--- a/backend/src/usecases/taskUsecase.ts
+++ b/backend/src/usecases/taskUsecase.ts
@@ -7,7 +7,7 @@ import type { TaskRepository } from '@/domain/repositories/taskRepository'
 export interface TaskUsecase {
   createTask(taskData: TaskData): Promise<Task>
   getTask(id: Task['id']): Promise<Task | undefined>
-  updateTask(id: Task['id'], taskData: Partial<TaskData>): Promise<Task>
+  updateTask(id: Task['id'], taskData: Partial<TaskData>): Promise<Task | undefined>
   deleteTask(id: Task['id']): Promise<Task | undefined>
   listTasks(
     sortBy: keyof Pick<Task, 'id' | 'due' | 'priority'>,
@@ -31,8 +31,7 @@ const updateTask = (repository: TaskRepository): TaskUsecase['updateTask'] =>
   async (id: Task['id'], taskData: Partial<TaskData>) => {
     const stored = await repository.getTask(id)
     if (stored === undefined) {
-      // FIXME: Resultの出番か?
-      throw new Error('!?')
+      return undefined
     }
     const updated: Task = {
       ...stored,

--- a/frontend/src/components/tasks/TaskList.vue
+++ b/frontend/src/components/tasks/TaskList.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { BIconArrowClockwise } from 'bootstrap-icons-vue'
 import TaskListRow from './TaskListRow.vue'
 import type { TaskListItem } from '@/entities/task'
 
@@ -6,22 +7,23 @@ const props = defineProps<{
   tasks: TaskListItem[]
   hasNext: boolean
   isLoading: boolean
+  error: Error | undefined
 }>()
 const emits = defineEmits<{
-  (
-    operation: 'remove',
-    id: TaskListItem['id']
-  ): void
-  (
-    operation: 'next',
-  ): void
+  (operation: 'remove', id: TaskListItem['id']): void
+  (operation: 'next' | 'reload'): void
 }>()
+
+const isScrollDisabled = props.isLoading
+  || !props.hasNext
+  || props.error !== undefined
+
 </script>
 
 <template>
   <ul
     v-infinite-scroll="()=>emits('next')"
-    :infinite-scroll-disabled="isLoading || !hasNext"
+    :infinite-scroll-disabled="isScrollDisabled"
     class="task-list"
   >
     <li
@@ -33,11 +35,13 @@ const emits = defineEmits<{
         @remove="emits('remove', task.id)"
       />
     </li>
+
     <li
       v-if="isLoading"
       v-loading="isLoading"
       style="height: 60px"
     />
+
     <li
       v-if="!isLoading && !hasNext"
       class="last-element-info"
@@ -47,6 +51,19 @@ const emits = defineEmits<{
       >
         最後のアイテムです
       </el-text>
+    </li>
+
+    <li
+      v-if="error"
+      class="error-info"
+    >
+      <div>読み込みに失敗しました: {{ error.message }}</div>
+      <el-button
+        :icon="BIconArrowClockwise"
+        @click="emits('reload')"
+      >
+        再試行
+      </el-button>
     </li>
   </ul>
 </template>
@@ -66,5 +83,13 @@ li.last-element-info {
   padding: 5px 0;
   text-align: center;
   user-select: none;
+}
+
+li.error-info {
+  text-align: center;
+}
+
+li.error-info>*:not(:last-child){
+  margin-bottom: 10px;
 }
 </style>

--- a/frontend/src/components/tasks/TaskList.vue
+++ b/frontend/src/components/tasks/TaskList.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { BIconArrowClockwise } from 'bootstrap-icons-vue'
+import { computed } from 'vue'
 import TaskListRow from './TaskListRow.vue'
 import type { TaskListItem } from '@/entities/task'
 
@@ -14,9 +15,9 @@ const emits = defineEmits<{
   (operation: 'next' | 'reload'): void
 }>()
 
-const isScrollDisabled = props.isLoading
-  || !props.hasNext
-  || props.error !== undefined
+const isScrollDisabled = computed(() => {
+  return props.isLoading || !props.hasNext || props.error !== undefined
+})
 
 </script>
 

--- a/frontend/src/composables/useTaskData.ts
+++ b/frontend/src/composables/useTaskData.ts
@@ -7,28 +7,23 @@ import {
 export const useTaskData = (id: Task['id']) => {
   const isLoading = ref(true)
 
-  // TODO: ここってResultだったりしないか
   const task = ref<Task>()
   const error = ref<Error>()
 
   const fetchData = async (id: Task['id']) => {
     isLoading.value = true
-    error.value = undefined
-
-    const fetchedTask = await getTask(id)
-    if (fetchedTask === undefined) {
-      error.value = new Error(`no such task with id ${id}`)
+    const fetchResult = await getTask(id)
+    fetchResult.match((fetchedTask) => {
+      error.value = undefined
+      task.value = fetchedTask
+    }, (fetchError) => {
+      error.value = fetchError
       task.value = undefined
-      isLoading.value = false
-      return
-    }
-    task.value = fetchedTask
+    })
     isLoading.value = false
   }
 
   const update = async (input: Omit<Task, 'id'>) => {
-    error.value = undefined
-
     const exist = task.value
     if (exist === undefined) {
       error.value = new Error('update() invoked before fetch completed')
@@ -36,18 +31,17 @@ export const useTaskData = (id: Task['id']) => {
     }
 
     isLoading.value = true
-
-    const updatedTask = await updateTask({
+    const updateResult = await updateTask({
       exist,
       input,
     })
-    if (updatedTask === undefined) {
-      error.value = new Error(`no such task with id ${id}`)
+    updateResult.match((updatedTask) => {
+      error.value = undefined
+      task.value = updatedTask
+    }, (updateError) => {
+      error.value = updateError
       task.value = undefined
-      isLoading.value = false
-      return
-    }
-    task.value = updatedTask
+    })
     isLoading.value = false
   }
 

--- a/frontend/src/composables/useTaskData.ts
+++ b/frontend/src/composables/useTaskData.ts
@@ -11,7 +11,6 @@ export const useTaskData = (id: Task['id']) => {
 
   const task = ref<Task>()
 
-  /** @deprecated これ経由で取得するのはやりづらい！ */
   const error = ref<Error>()
 
   const fetchData = async (id: Task['id']) => {
@@ -54,7 +53,6 @@ export const useTaskData = (id: Task['id']) => {
   return {
     task,
     isLoading,
-    /** @deprecated */
     error,
     update,
     remove,

--- a/frontend/src/composables/useTaskData.ts
+++ b/frontend/src/composables/useTaskData.ts
@@ -1,10 +1,6 @@
 import { ref } from 'vue'
-import { err } from 'neverthrow'
-import type { Result } from 'neverthrow'
 import type { Task } from '@/entities/task'
-import {
-  deleteTask, getTask, updateTask,
-} from '@/repositories/taskRepository'
+import { getTask } from '@/repositories/taskRepository'
 
 export const useTaskData = (id: Task['id']) => {
   const isLoading = ref(true)
@@ -26,35 +22,11 @@ export const useTaskData = (id: Task['id']) => {
     isLoading.value = false
   }
 
-  const update = async (input: Omit<Task, 'id'>): Promise<Result<Task, Error>> => {
-    const exist = task.value
-    if (exist === undefined) {
-      return err(new Error('update() invoked before fetch completed'))
-    }
-
-    isLoading.value = true
-    const result = await updateTask({
-      exist,
-      input,
-    })
-    isLoading.value = false
-    return result
-  }
-
-  const remove = async (): Promise<Result<Task, Error>> => {
-    isLoading.value = true
-    const result = await deleteTask(id)
-    isLoading.value = false
-    return result
-  }
-
   fetchData(id)
 
   return {
     task,
     isLoading,
     error,
-    update,
-    remove,
   }
 }

--- a/frontend/src/composables/useTaskList.ts
+++ b/frontend/src/composables/useTaskList.ts
@@ -3,7 +3,7 @@ import {
 } from 'vue'
 import type { Ref } from 'vue'
 import type { TaskListItem } from '@/entities/task'
-import { deleteTask, listTask } from '@/repositories/taskRepository'
+import { listTask } from '@/repositories/taskRepository'
 
 type ListTaskParams = Parameters<typeof listTask>[0]
 
@@ -49,19 +49,6 @@ export const useTaskList = (props: {
     await next()
   }
 
-  const remove = async (id: TaskListItem['id']) => {
-    isLoading.value = true
-    const deletionResult = await deleteTask(id)
-    deletionResult.match((deletedTask) => {
-      error.value = undefined
-      // ローカルのtasksを全部洗い直すのはやばいので、filterで消す
-      tasks.value = tasks.value.filter(task => task.id !== deletedTask.id)
-    }, (deleteError) => {
-      error.value = deleteError
-    })
-    isLoading.value = false
-  }
-
   watch([props.key, props.order, props.itemPerPage], async (_, prevValue) => {
     // prevValueがある = 初回でないと判断、ロード中ならpreventする
     if (prevValue.length > 0 && isLoading.value) {
@@ -78,6 +65,5 @@ export const useTaskList = (props: {
     next,
     reload,
     hasNext,
-    remove,
   }
 }

--- a/frontend/src/composables/useTaskList.ts
+++ b/frontend/src/composables/useTaskList.ts
@@ -23,8 +23,6 @@ export const useTaskList = (props: {
 
   const next = async () => {
     isLoading.value = true
-    error.value = undefined
-
     const fetchResult = await listTask({
       key: toValue(props.key),
       order: toValue(props.order),
@@ -33,6 +31,7 @@ export const useTaskList = (props: {
     })
 
     fetchResult.match((fetchedTasks) => {
+      error.value = undefined
       tasks.value.push(...fetchedTasks)
       offset.value += fetchedTasks.length
       hasNext.value = fetchedTasks.length > 0
@@ -54,6 +53,7 @@ export const useTaskList = (props: {
     isLoading.value = true
     const deletionResult = await deleteTask(id)
     deletionResult.match((deletedTask) => {
+      error.value = undefined
       // ローカルのtasksを全部洗い直すのはやばいので、filterで消す
       tasks.value = tasks.value.filter(task => task.id !== deletedTask.id)
     }, (deleteError) => {

--- a/frontend/src/composables/useTaskList.ts
+++ b/frontend/src/composables/useTaskList.ts
@@ -25,15 +25,20 @@ export const useTaskList = (props: {
     isLoading.value = true
     error.value = undefined
 
-    const fetchedTasks = await listTask({
+    const fetchResult = await listTask({
       key: toValue(props.key),
       order: toValue(props.order),
       limit: limit.value,
       offset: offset.value,
     })
-    tasks.value.push(...fetchedTasks)
-    offset.value += fetchedTasks.length
-    hasNext.value = fetchedTasks.length > 0
+
+    fetchResult.match((fetchedTasks) => {
+      tasks.value.push(...fetchedTasks)
+      offset.value += fetchedTasks.length
+      hasNext.value = fetchedTasks.length > 0
+    }, (fetchError) => {
+      error.value = fetchError
+    })
     isLoading.value = false
   }
 
@@ -47,15 +52,13 @@ export const useTaskList = (props: {
 
   const remove = async (id: TaskListItem['id']) => {
     isLoading.value = true
-    const result = await deleteTask(id)
-    if (result === undefined) {
-      error.value = new Error('No such item')
-      isLoading.value = false
-      return
-    }
-
-    // ローカルのtasksを全部洗い直すのはやばいので、filterで消す
-    tasks.value = tasks.value.filter(task => task.id !== result.id)
+    const deletionResult = await deleteTask(id)
+    deletionResult.match((deletedTask) => {
+      // ローカルのtasksを全部洗い直すのはやばいので、filterで消す
+      tasks.value = tasks.value.filter(task => task.id !== deletedTask.id)
+    }, (deleteError) => {
+      error.value = deleteError
+    })
     isLoading.value = false
   }
 

--- a/frontend/src/composables/useTaskOperation.ts
+++ b/frontend/src/composables/useTaskOperation.ts
@@ -1,0 +1,42 @@
+import { err } from 'neverthrow'
+import type { Result } from 'neverthrow'
+import { ref } from 'vue'
+import type { Task } from '@/entities/task'
+import { updateTask, deleteTask } from '@/repositories/taskRepository'
+
+export const useTaskOperation = () => {
+  const isOperating = ref(false)
+
+  const update = async ({ exist, input }: {
+    exist: Task
+    input: Omit<Task, 'id'>
+  }): Promise<Result<Task, Error>> => {
+    if (isOperating.value) {
+      return err(new Error('Now processing'))
+    }
+    isOperating.value = true
+    const result = await updateTask({
+      exist,
+      input,
+    })
+    isOperating.value = false
+    return result
+  }
+
+  const remove = async (id: Task['id']): Promise<Result<Task, Error>> => {
+    if (isOperating.value) {
+      return err(new Error('Now processing'))
+    }
+
+    isOperating.value = true
+    const result = await deleteTask(id)
+    isOperating.value = false
+    return result
+  }
+
+  return {
+    isOperating,
+    update,
+    remove,
+  }
+}

--- a/frontend/src/pages/tasks/[id].vue
+++ b/frontend/src/pages/tasks/[id].vue
@@ -18,7 +18,7 @@ const {
 } = useTaskData(route.params.id)
 
 const {
-  update, remove, isOperating,
+  update, remove, isOperating: _,
 } = useTaskOperation()
 
 watch(task, () => {

--- a/frontend/src/pages/tasks/[id].vue
+++ b/frontend/src/pages/tasks/[id].vue
@@ -58,7 +58,7 @@ const onClickRemove = async () => {
       </template>
 
       <template v-if="error">
-        <div>some error occured: {{ error.message }}</div>
+        <div>読み込みに失敗しました: {{ error.message }}</div>
       </template>
 
       <template v-if="task">

--- a/frontend/src/pages/tasks/index.vue
+++ b/frontend/src/pages/tasks/index.vue
@@ -40,6 +40,7 @@ const {
   isLoading,
   next,
   hasNext,
+  error,
   remove,
 } = useTaskList({
   key,
@@ -108,10 +109,12 @@ const onClickOrder = () => {
     >
       <TaskList
         :tasks="tasks"
+        :error="error"
         :has-next="hasNext"
         :is-loading="isLoading"
         @remove="remove"
         @next="next"
+        @reload="next"
       />
     </el-col>
   </el-row>

--- a/frontend/src/repositories/errors.ts
+++ b/frontend/src/repositories/errors.ts
@@ -1,0 +1,22 @@
+import type { Task } from '@/entities/task'
+
+/** Repositoryレイヤのエラー */
+export class RepositoryError extends Error {}
+
+/** ネットワークエラー */
+export class NetworkError extends RepositoryError {}
+
+// MARK: Task
+
+/** Taskリポジトリのエラー */
+export class TaskRepositoryError extends RepositoryError {}
+
+/** 指定されたIDのタスクは存在しない */
+export class NoSuchItemError extends TaskRepositoryError {
+  id: Task['id']
+
+  constructor(message: string, id: Task['id']) {
+    super(message)
+    this.id = id
+  }
+}

--- a/frontend/src/repositories/errors.ts
+++ b/frontend/src/repositories/errors.ts
@@ -15,8 +15,8 @@ export class TaskRepositoryError extends RepositoryError {}
 export class NoSuchItemError extends TaskRepositoryError {
   id: Task['id']
 
-  constructor(message: string, id: Task['id']) {
-    super(message)
+  constructor(id: Task['id']) {
+    super(`No such item with id ${id}`)
     this.id = id
   }
 }

--- a/frontend/src/repositories/taskRepository.ts
+++ b/frontend/src/repositories/taskRepository.ts
@@ -1,97 +1,129 @@
+import { err, ok } from 'neverthrow'
+import type { Result } from 'neverthrow'
 import { client } from './client'
+import { NoSuchItemError, NetworkError } from './errors'
 import dayjs from '@/logic/dayjs'
 import type { Task, TaskListItem } from '@/entities/task'
-
-// TODO: error handling or use `Result`
 
 export const listTask = async (query: {
   key?: 'id' | 'due' | 'priority'
   order?: 'desc' | 'asc'
   limit?: number
   offset?: number
-}): Promise<TaskListItem[]> => {
-  const response = await client.task.$get({
-    query: {
-      ...query,
-      limit: query.limit?.toString(),
-      offset: query.offset?.toString(),
-    },
-  })
-  const taskDatas = await response.json()
-  const tasks: TaskListItem[] = taskDatas.map(task => ({
-    ...task,
-    due: dayjs(task.due),
-  }))
-  return tasks
+}): Promise<Result<TaskListItem[], NetworkError>> => {
+  try {
+    const response = await client.task.$get({
+      query: {
+        ...query,
+        limit: query.limit?.toString(),
+        offset: query.offset?.toString(),
+      },
+    })
+
+    const taskDatas = await response.json()
+    const tasks: TaskListItem[] = taskDatas.map(task => ({
+      ...task,
+      due: dayjs(task.due),
+    }))
+    return ok(tasks)
+  }
+  catch (error: unknown) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
+  }
 }
 
-export const addTask = async (task: Omit<Task, 'id'>): Promise<Task> => {
-  const response = await client.task.$post({
-    json: {
-      ...task,
-      due: task.due.utc().valueOf(),
-    },
-  })
+export const addTask = async (task: Omit<Task, 'id'>): Promise<Result<Task, NetworkError>> => {
+  try {
+    const response = await client.task.$post({
+      json: {
+        ...task,
+        due: task.due.utc().valueOf(),
+      },
+    })
 
-  const newTaskData = await response.json()
-  return {
-    ...newTaskData,
-    due: dayjs(newTaskData.due),
+    const newTaskData = await response.json()
+    return ok({
+      ...newTaskData,
+      due: dayjs(newTaskData.due),
+    })
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
   }
 }
 
 export const getTask = async (id: TaskListItem['id']):
-Promise<Task | undefined> => {
-  const response = await client.task[':id'].$get({ param: { id } })
-  if (!response.ok) {
-    return undefined
-  }
+Promise<Result<Task, NoSuchItemError | NetworkError>> => {
+  try {
+    const response = await client.task[':id'].$get({ param: { id } })
+    if (!response.ok) {
+      return err(new NoSuchItemError('', id))
+    }
 
-  const taskData = await response.json()
-  return {
-    ...taskData,
-    due: dayjs(taskData.due),
+    const taskData = await response.json()
+    return ok({
+      ...taskData,
+      due: dayjs(taskData.due),
+    })
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
   }
 }
 
 export const updateTask = async (props: {
   exist: Task
   input: Partial<Omit<Task, 'id'>>
-}): Promise<Task | undefined> => {
-  const updatedData: Task = {
-    ...props.exist,
-    ...props.input,
-  }
-  const response = await client.task[':id'].$put({
-    param: { id: props.exist.id },
-    json: {
-      title: updatedData.title,
-      description: updatedData.description,
-      due: updatedData.due.utc().valueOf(),
-      priority: updatedData.priority,
-    },
-  })
-  if (!response.ok) {
-    return undefined
-  }
+}): Promise<Result<Task, NoSuchItemError | NetworkError>> => {
+  try {
+    const updatedData: Task = {
+      ...props.exist,
+      ...props.input,
+    }
+    const response = await client.task[':id'].$put({
+      param: { id: props.exist.id },
+      json: {
+        title: updatedData.title,
+        description: updatedData.description,
+        due: updatedData.due.utc().valueOf(),
+        priority: updatedData.priority,
+      },
+    })
+    if (!response.ok) {
+      return err(new NoSuchItemError('', props.exist.id))
+    }
 
-  const updatedTask = await response.json()
-  return {
-    ...updatedTask,
-    due: dayjs(updatedTask.due),
+    const updatedTask = await response.json()
+    return ok({
+      ...updatedTask,
+      due: dayjs(updatedTask.due),
+    })
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
   }
 }
 
 export const deleteTask = async (id: Task['id']):
-Promise<Task | undefined> => {
-  const response = await client.task[':id'].$delete({ param: { id } })
-  if (!response.ok) {
-    return undefined
-  }
+Promise<Result<Task, NoSuchItemError | NetworkError>> => {
+  try {
+    const response = await client.task[':id'].$delete({ param: { id } })
+    if (!response.ok) {
+      return err(new NoSuchItemError('', id))
+    }
 
-  const deletedTaskData = await response.json()
-  return {
-    ...deletedTaskData,
-    due: dayjs(deletedTaskData.due),
+    const deletedTaskData = await response.json()
+    return ok({
+      ...deletedTaskData,
+      due: dayjs(deletedTaskData.due),
+    })
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
   }
 }

--- a/frontend/src/repositories/taskRepository.ts
+++ b/frontend/src/repositories/taskRepository.ts
@@ -59,7 +59,7 @@ Promise<Result<Task, NoSuchItemError | NetworkError>> => {
   try {
     const response = await client.task[':id'].$get({ param: { id } })
     if (!response.ok) {
-      return err(new NoSuchItemError('', id))
+      return err(new NoSuchItemError(id))
     }
 
     const taskData = await response.json()
@@ -93,7 +93,7 @@ export const updateTask = async (props: {
       },
     })
     if (!response.ok) {
-      return err(new NoSuchItemError('', props.exist.id))
+      return err(new NoSuchItemError(props.exist.id))
     }
 
     const updatedTask = await response.json()
@@ -113,7 +113,7 @@ Promise<Result<Task, NoSuchItemError | NetworkError>> => {
   try {
     const response = await client.task[':id'].$delete({ param: { id } })
     if (!response.ok) {
-      return err(new NoSuchItemError('', id))
+      return err(new NoSuchItemError(id))
     }
 
     const deletedTaskData = await response.json()

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
         "frontend"
       ],
       "dependencies": {
-        "hono": "^4.6.20"
+        "hono": "^4.6.20",
+        "neverthrow": "^8.1.1"
       },
       "devDependencies": {
         "@cloudflare/workers-types": "^4.20250129.0",
@@ -2154,7 +2155,6 @@
       "cpu": [
         "x64"
       ],
-      "dev": true,
       "optional": true,
       "os": [
         "linux"
@@ -5577,6 +5577,18 @@
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true
+    },
+    "node_modules/neverthrow": {
+      "version": "8.1.1",
+      "resolved": "https://registry.npmjs.org/neverthrow/-/neverthrow-8.1.1.tgz",
+      "integrity": "sha512-DpbZ/UDI0B+TxJB1JysXSfi1++3YK2xLBqQLTlRN0b4zxlZ2MoiB+dKKV8dMRzt1fAFjRKDknXOVJgpl+a4Amw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-linux-x64-gnu": "^4.24.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "wrangler": "^3.106.0"
   },
   "dependencies": {
-    "hono": "^4.6.20"
+    "hono": "^4.6.20",
+    "neverthrow": "^8.1.1"
   }
 }


### PR DESCRIPTION
Fixes: #32

フロントエンドのrepoレイヤにResultを導入しました。

- **feat: #32 add errortype, use result on frontend repository**
- **fix: #32 バックエンドでPUTする際、該当エントリがなければundefinedを返す**
- **test: #32 テストケース追加**
- **feat: #32 タスクリストのエラーハンドリング**
- **feat: #32 タスク詳細のエラーハンドリング**
- **fix: #32 スクロール可否状態をcomputedで保持**
- **feat: #32 NoSuchItemErrorの引数を簡素化**
- **feat: #32 タスク更新・削除時のエラーハンドリング**
- **fix: #32 deprecatedフラグを削除**
- **feat: #32 タスクアイテムの更新処理を分割**
