### PR TITLE
fix: #48 フォントファミリの定義位置を修正

### DIFF
--- a/frontend/src/styles/index.scss
+++ b/frontend/src/styles/index.scss
@@ -5,18 +5,9 @@
   --el-main-padding: 20px;
   --el-aside-width: 220px;
   --el-header-height: 60px;
-  --el-font-family: "Helvetica Neue",
-    Arial,
-    "Hiragino Kaku Gothic ProN",
-    "Hiragino Sans",
-    Meiryo,
-    sans-serif;
-  font-family: var(--el-font-family);
 }
 
 body {
-  font-family: var(--el-font-family);
-
   margin: 0;
   padding: 0;
 

--- a/frontend/src/styles/theme/index.scss
+++ b/frontend/src/styles/theme/index.scss
@@ -5,3 +5,12 @@
 );
 
 @use './dark.scss';
+
+:root {
+  --el-font-family: "Helvetica Neue",
+  Arial,
+  "Hiragino Kaku Gothic ProN",
+  "Hiragino Sans",
+  Meiryo,
+  sans-serif;
+}

--- a/hono_rpc_sample.code-workspace
+++ b/hono_rpc_sample.code-workspace
@@ -38,6 +38,9 @@
     },
     "[scss]": {
       "editor.defaultFormatter": "vscode.css-language-features"
+    },
+    "[css]": {
+      "editor.defaultFormatter": "vscode.css-language-features"
     }
   },
   "extensions": {


### PR DESCRIPTION
Fixes: #48

- これまでは styles/index.scss で設定していた。
- このため、element-plusのスタイルより先に --el-font-family が設定されてしまい、中華フォントに置き換わる不具合が発生していた。
- additionalDataとして読み込んでいる styles/theme/index.scss で読むよう変更することで、CSS変数の定義順が逆転し、正しくフォントが当たるようになった。
