### PR TITLE
OpenAPIスキーマを生成するようにした

### DIFF
--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -7,10 +7,6 @@
   },
   "servers": [
     {
-      "url": "http://localhost:8787",
-      "description": "Local server"
-    },
-    {
       "url": "https://api.hono-rpc-sample.enchan.me",
       "description": "Production server"
     }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,5 +1,5 @@
 {
-  "openapi": "3.1.0",
+  "openapi": "3.0.3",
   "info": {
     "title": "api.hono-rpc-sample.enchan.me",
     "description": "API for hono-rpc-sample",

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -15,6 +15,21 @@
       "description": "Production server"
     }
   ],
+  "components": {
+    "securitySchemes": {
+      "bearerAuth": {
+        "type": "http",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
+      }
+    },
+    "schemas": {}
+  },
+  "security": [
+    {
+      "bearerAuth": []
+    }
+  ],
   "paths": {
     "/task": {
       "get": {
@@ -175,8 +190,5 @@
         ]
       }
     }
-  },
-  "components": {
-    "schemas": {}
   }
 }

--- a/backend/openapi.json
+++ b/backend/openapi.json
@@ -1,0 +1,182 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "api.hono-rpc-sample.enchan.me",
+    "description": "API for hono-rpc-sample",
+    "version": "0.0.0"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8787",
+      "description": "Local server"
+    },
+    {
+      "url": "https://api.hono-rpc-sample.enchan.me",
+      "description": "Production server"
+    }
+  ],
+  "paths": {
+    "/task": {
+      "get": {
+        "responses": {},
+        "operationId": "getTask",
+        "parameters": [
+          {
+            "in": "query",
+            "name": "key",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "id",
+                "due",
+                "priority"
+              ],
+              "default": "due"
+            }
+          },
+          {
+            "in": "query",
+            "name": "order",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "asc",
+                "desc"
+              ],
+              "default": "desc"
+            }
+          },
+          {
+            "in": "query",
+            "name": "limit",
+            "schema": {
+              "type": "string",
+              "default": "20"
+            }
+          },
+          {
+            "in": "query",
+            "name": "offset",
+            "schema": {
+              "type": "string"
+            }
+          }
+        ]
+      },
+      "post": {
+        "responses": {},
+        "operationId": "postTask",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "due": {
+                    "type": "number"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "high",
+                      "middle",
+                      "low"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                },
+                "required": [
+                  "title",
+                  "due",
+                  "priority",
+                  "description"
+                ]
+              }
+            }
+          }
+        }
+      }
+    },
+    "/task/{id}": {
+      "get": {
+        "responses": {},
+        "operationId": "getTaskById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ]
+      },
+      "put": {
+        "responses": {},
+        "operationId": "putTaskById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "due": {
+                    "type": "number"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "high",
+                      "middle",
+                      "low"
+                    ]
+                  },
+                  "description": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "delete": {
+        "responses": {},
+        "operationId": "deleteTaskById",
+        "parameters": [
+          {
+            "in": "path",
+            "name": "id",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          }
+        ]
+      }
+    }
+  },
+  "components": {
+    "schemas": {}
+  }
+}

--- a/backend/package.json
+++ b/backend/package.json
@@ -9,7 +9,8 @@
     "predeploy": "npm run build",
     "deploy": "wrangler --env=production deploy",
     "db:init": "wrangler --env=development d1 execute hono-rpc-sample-backend-db --local --file='src/infrastructure/migrations/0000-init.sql'",
-    "db:init:remote": "wrangler --env=production d1 execute hono-rpc-sample-backend-db --remote --file='src/infrastructure/migrations/0000-init.sql'"
+    "db:init:remote": "wrangler --env=production d1 execute hono-rpc-sample-backend-db --remote --file='src/infrastructure/migrations/0000-init.sql'",
+    "gen:apispec": "tsx src/scripts/apispec.ts"
   },
   "dependencies": {
     "hono-openapi": "^0.4.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,8 +12,10 @@
     "db:init:remote": "wrangler --env=production d1 execute hono-rpc-sample-backend-db --remote --file='src/infrastructure/migrations/0000-init.sql'"
   },
   "dependencies": {
+    "hono-openapi": "^0.4.6",
     "ulid": "^2.3.0",
-    "zod": "^3.24.1"
+    "zod": "^3.24.2",
+    "zod-openapi": "^4.2.4"
   },
   "devDependencies": {
     "@cloudflare/vitest-pool-workers": "^0.6.10",

--- a/backend/src/presentations/tasks.ts
+++ b/backend/src/presentations/tasks.ts
@@ -1,6 +1,6 @@
-import { zValidator } from '@hono/zod-validator'
 import { Hono } from 'hono'
 import { createMiddleware } from 'hono/factory'
+import { validator as zValidator } from 'hono-openapi/zod'
 import { z } from 'zod'
 
 import { TaskPriorities } from '@/domain/entities/task'

--- a/backend/src/scripts/apispec.ts
+++ b/backend/src/scripts/apispec.ts
@@ -32,6 +32,9 @@ const main = async () => {
       },
       security: [{ bearerAuth: [] }],
     },
+  }, {
+    version: '3.0.3',
+    components: {},
   })
 
   const schemeString = JSON.stringify(schema, undefined, 2)

--- a/backend/src/scripts/apispec.ts
+++ b/backend/src/scripts/apispec.ts
@@ -1,0 +1,33 @@
+import * as fs from 'fs/promises'
+import { generateSpecs } from 'hono-openapi'
+
+import app from '@/presentations'
+
+const main = async () => {
+  const schema = await generateSpecs(app, {
+    documentation: {
+      info: {
+        title: 'api.hono-rpc-sample.enchan.me',
+        version: '0.0.0',
+        description: 'API for hono-rpc-sample',
+      },
+      servers: [
+        {
+          url: 'http://localhost:8787',
+          description: 'Local server',
+        },
+        {
+          url: 'https://api.hono-rpc-sample.enchan.me',
+          description: 'Production server',
+        },
+      ],
+    },
+  })
+
+  const schemeString = JSON.stringify(schema, undefined, 2)
+  const filePath = `./${process.argv.at(2) ?? 'openapi.json'}`
+
+  await fs.writeFile(filePath, schemeString)
+}
+
+main().catch(() => process.exit(1))

--- a/backend/src/scripts/apispec.ts
+++ b/backend/src/scripts/apispec.ts
@@ -13,10 +13,6 @@ const main = async () => {
       },
       servers: [
         {
-          url: 'http://localhost:8787',
-          description: 'Local server',
-        },
-        {
           url: 'https://api.hono-rpc-sample.enchan.me',
           description: 'Production server',
         },

--- a/backend/src/scripts/apispec.ts
+++ b/backend/src/scripts/apispec.ts
@@ -21,6 +21,16 @@ const main = async () => {
           description: 'Production server',
         },
       ],
+      components: {
+        securitySchemes: {
+          bearerAuth: {
+            type: 'http',
+            scheme: 'bearer',
+            bearerFormat: 'JWT',
+          },
+        },
+      },
+      security: [{ bearerAuth: [] }],
     },
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,8 +31,10 @@
     },
     "backend": {
       "dependencies": {
+        "hono-openapi": "^0.4.6",
         "ulid": "^2.3.0",
-        "zod": "^3.24.1"
+        "zod": "^3.24.2",
+        "zod-openapi": "^4.2.4"
       },
       "devDependencies": {
         "@cloudflare/vitest-pool-workers": "^0.6.10",
@@ -133,6 +135,23 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@apidevtools/json-schema-ref-parser": {
+      "version": "11.9.3",
+      "resolved": "https://registry.npmjs.org/@apidevtools/json-schema-ref-parser/-/json-schema-ref-parser-11.9.3.tgz",
+      "integrity": "sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jsdevtools/ono": "^7.1.3",
+        "@types/json-schema": "^7.0.15",
+        "js-yaml": "^4.1.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/philsturgeon"
       }
     },
     "node_modules/@auth0/auth0-spa-js": {
@@ -1483,7 +1502,7 @@
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.4.2.tgz",
       "integrity": "sha512-1rrlBg+EpDPhzOV4hT9pxr5+xDVmKuz6YJl+la7VCwK6ass5ldyKm5fD+umJdV2zhHD6jROoCCv8NbTwyfhT0g==",
-      "dev": true,
+      "devOptional": true,
       "peerDependencies": {
         "hono": ">=3.9.0",
         "zod": "^3.19.1"
@@ -1956,6 +1975,12 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
+    "node_modules/@jsdevtools/ono": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/@jsdevtools/ono/-/ono-7.1.3.tgz",
+      "integrity": "sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==",
+      "license": "MIT"
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2347,8 +2372,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
-      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-      "dev": true
+      "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3143,8 +3167,7 @@
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="
     },
     "node_modules/array-buffer-byte-length": {
       "version": "1.0.2",
@@ -3565,6 +3588,15 @@
       "integrity": "sha512-9z8TZaGM1pfswYeXrUpzPrkx8UnWYdhJclsiYMm6x/w5+nN+8Tf/LnAgfLGQCm59qAOxU8WwHEq2vNwF6i4j+Q==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/clone": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+      "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
+      }
     },
     "node_modules/color": {
       "version": "4.2.3",
@@ -4893,6 +4925,75 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/hono-openapi": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/hono-openapi/-/hono-openapi-0.4.6.tgz",
+      "integrity": "sha512-wSDySp2cS5Zcf1OeLG7nCP3eMsCpcDomN137T9B6/Z5Qq3D0nWgMf0I3Gl41SE1rE37OBQ0Smqx3LOP9Hk//7A==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-walker": "^2.0.0"
+      },
+      "peerDependencies": {
+        "@hono/arktype-validator": "^2.0.0",
+        "@hono/effect-validator": "^1.2.0",
+        "@hono/typebox-validator": "^0.2.0 || ^0.3.0",
+        "@hono/valibot-validator": "^0.5.1",
+        "@hono/zod-validator": "^0.4.1",
+        "@sinclair/typebox": "^0.34.9",
+        "@valibot/to-json-schema": "^1.0.0-beta.3",
+        "arktype": "^2.0.0-rc.25",
+        "effect": "^3.11.3",
+        "hono": "^4.6.13",
+        "openapi-types": "^12.1.3",
+        "valibot": "^1.0.0-beta.9",
+        "zod": "^3.23.8",
+        "zod-openapi": "^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@hono/arktype-validator": {
+          "optional": true
+        },
+        "@hono/effect-validator": {
+          "optional": true
+        },
+        "@hono/typebox-validator": {
+          "optional": true
+        },
+        "@hono/valibot-validator": {
+          "optional": true
+        },
+        "@hono/zod-validator": {
+          "optional": true
+        },
+        "@sinclair/typebox": {
+          "optional": true
+        },
+        "@valibot/to-json-schema": {
+          "optional": true
+        },
+        "arktype": {
+          "optional": true
+        },
+        "effect": {
+          "optional": true
+        },
+        "hono": {
+          "optional": true
+        },
+        "openapi-types": {
+          "optional": true
+        },
+        "valibot": {
+          "optional": true
+        },
+        "zod": {
+          "optional": true
+        },
+        "zod-openapi": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -5344,7 +5445,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "dependencies": {
         "argparse": "^2.0.1"
       },
@@ -5363,6 +5463,19 @@
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
       "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
       "dev": true
+    },
+    "node_modules/json-schema-walker": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-walker/-/json-schema-walker-2.0.0.tgz",
+      "integrity": "sha512-nXN2cMky0Iw7Af28w061hmxaPDaML5/bQD9nwm1lOoIKEGjHcRGxqWe4MfrkYThYAPjSUhmsp4bJNoLAyVn9Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@apidevtools/json-schema-ref-parser": "^11.1.0",
+        "clone": "^2.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -10080,11 +10193,24 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.24.1",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.1.tgz",
-      "integrity": "sha512-muH7gBL9sI1nciMZV67X5fTKKBLtwpZ5VBp1vsOQzj1MhrBZ4wlVCm3gedKZWLp0Oyel8sIGfeiz54Su+OVT+A==",
+      "version": "3.24.2",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.24.2.tgz",
+      "integrity": "sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==",
+      "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-openapi": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/zod-openapi/-/zod-openapi-4.2.4.tgz",
+      "integrity": "sha512-tsrQpbpqFCXqVXUzi3TPwFhuMtLN3oNZobOtYnK6/5VkXsNdnIgyNr4r8no4wmYluaxzN3F7iS+8xCW8BmMQ8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.21.4"
       }
     }
   }


### PR DESCRIPTION
Fixes: #52

- **chore: install hono-openapi**
- **feat: replace zValidator to hono-openapi/zod**
- **feat: OpenAPI specを吐くスクリプトを追加**
- **feat: #52 OpenAPIスキーマを生成**
- **feat: #52 OpenAPIに認証情報を追加**
- **chore: #52 OpenAPIバージョンを設定**
- **chore: #52 ローカルサーバの定義を削除**
- **chore: #52 ローカルサーバの定義を削除**
