### PR TITLE
ログインボタンにユーザ情報を表示するようにした

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { useAuth0 } from '@auth0/auth0-vue'
 import {
   breakpointsElement, useBreakpoints, useDark,
 } from '@vueuse/core'
@@ -7,12 +6,9 @@ import { BIconList } from 'bootstrap-icons-vue'
 import { ref, watch } from 'vue'
 
 import Sidebar from '@/components/SideBar.vue'
+import UserButton from '@/components/UserButton.vue'
 
 useDark()
-
-const {
-  loginWithRedirect, isAuthenticated, logout,
-} = useAuth0()
 
 const breakpoints = useBreakpoints(breakpointsElement)
 const isSmartphone = breakpoints.smaller('sm')
@@ -23,10 +19,6 @@ watch(isSmartphone, (newValue, prevValue) => {
 })
 
 const isSidebarVisible = ref(!isSmartphone.value)
-
-const onClickLogout = async () => {
-  await logout({ logoutParams: { returnTo: window.location.origin } })
-}
 </script>
 
 <template>
@@ -40,18 +32,7 @@ const onClickLogout = async () => {
           />
         </span>
         <h1>Tasks</h1>
-        <el-button
-          v-if="!isAuthenticated"
-          @click="loginWithRedirect()"
-        >
-          Login
-        </el-button>
-        <el-button
-          v-else
-          @click="onClickLogout"
-        >
-          Logout
-        </el-button>
+        <UserButton />
       </el-row>
     </el-header>
     <el-container>

--- a/frontend/src/components/UserButton.vue
+++ b/frontend/src/components/UserButton.vue
@@ -58,7 +58,7 @@ const onClickLogout = async () => {
       <template #default>
         <el-row style="margin-bottom: 10px;">
           <el-text type="info">
-            mail@example.com
+            {{ user?.email }}
           </el-text>
         </el-row>
         <el-row justify="end">

--- a/frontend/src/components/UserButton.vue
+++ b/frontend/src/components/UserButton.vue
@@ -1,0 +1,73 @@
+<script setup lang="ts">
+import { useAuth0 } from '@auth0/auth0-vue'
+import { BIconPersonFill } from 'bootstrap-icons-vue'
+import { err } from 'neverthrow'
+import { onMounted, ref } from 'vue'
+
+import type { User } from '@/entities/user'
+import { getCurrentUser } from '@/repositories/userRepository'
+
+// MARK: - States
+
+const {
+  loginWithRedirect, isAuthenticated, logout, getAccessTokenSilently,
+} = useAuth0()
+
+const user = ref<User>()
+
+// MARK: - Event handlers
+
+onMounted(async () => {
+  user.value = await getAccessTokenSilently()
+    .then(token => getCurrentUser(token))
+    .catch(e => err(e))
+    .then(result => result.unwrapOr(undefined))
+})
+
+const onClickLogout = async () => {
+  await logout({ logoutParams: { returnTo: window.location.origin } })
+}
+
+</script>
+
+<template>
+  <template v-if="isAuthenticated">
+    <el-popover
+      trigger="click"
+      width="unset"
+      :title="user?.name"
+      placement="bottom-end"
+    >
+      <template #reference>
+        <el-button :icon="BIconPersonFill">
+          {{ user?.name }}
+        </el-button>
+      </template>
+      <template #default>
+        <el-row style="margin-bottom: 10px;">
+          <el-text type="info">
+            mail@example.com
+          </el-text>
+        </el-row>
+        <el-row justify="end">
+          <el-button
+            link
+            type="primary"
+            @click="onClickLogout()"
+          >
+            ログアウト
+          </el-button>
+        </el-row>
+      </template>
+    </el-popover>
+  </template>
+
+  <template v-else>
+    <el-button
+      :icon="BIconPersonFill"
+      @click="loginWithRedirect()"
+    >
+      ログイン
+    </el-button>
+  </template>
+</template>

--- a/frontend/src/components/UserButton.vue
+++ b/frontend/src/components/UserButton.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { useAuth0 } from '@auth0/auth0-vue'
+import { breakpointsElement, useBreakpoints } from '@vueuse/core'
 import { BIconPersonFill } from 'bootstrap-icons-vue'
 import { err } from 'neverthrow'
 import { onMounted, ref } from 'vue'
@@ -14,6 +15,9 @@ const {
 } = useAuth0()
 
 const user = ref<User>()
+
+const breakpoints = useBreakpoints(breakpointsElement)
+const isSmartphone = breakpoints.smaller('sm')
 
 // MARK: - Event handlers
 
@@ -39,7 +43,15 @@ const onClickLogout = async () => {
       placement="bottom-end"
     >
       <template #reference>
-        <el-button :icon="BIconPersonFill">
+        <el-button
+          v-if="isSmartphone"
+          :icon="BIconPersonFill"
+        />
+
+        <el-button
+          v-else
+          :icon="BIconPersonFill"
+        >
           {{ user?.name }}
         </el-button>
       </template>

--- a/frontend/src/entities/user.ts
+++ b/frontend/src/entities/user.ts
@@ -1,0 +1,4 @@
+export type User = {
+  id: string
+  name: string
+}

--- a/frontend/src/entities/user.ts
+++ b/frontend/src/entities/user.ts
@@ -1,4 +1,5 @@
 export type User = {
   id: string
   name: string
+  email: string
 }

--- a/frontend/src/repositories/userRepository.ts
+++ b/frontend/src/repositories/userRepository.ts
@@ -12,7 +12,12 @@ export const getCurrentUser = async (token: string): Promise<Result<User, Networ
       //
       headers: { Authorization: `Bearer ${token}` },
     })
-    return response.json().then(user => ok(user))
+
+    // TODO: #80 バックエンドからメールアドレスを取得できるようになったらオーバーライドを外す
+    return response.json().then(user => ok({
+      ...user,
+      email: 'mail@example.com',
+    }))
   }
   catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error'

--- a/frontend/src/repositories/userRepository.ts
+++ b/frontend/src/repositories/userRepository.ts
@@ -1,0 +1,21 @@
+import type { Result } from 'neverthrow'
+import { err, ok } from 'neverthrow'
+
+import type { User } from '@/entities/user'
+
+import { client } from './client'
+import { NetworkError } from './errors'
+
+export const getCurrentUser = async (token: string): Promise<Result<User, NetworkError>> => {
+  try {
+    const response = await client.user.me.$get({}, {
+      //
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    return response.json().then(user => ok(user))
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'unknown error'
+    return err(new NetworkError(message))
+  }
+}


### PR DESCRIPTION
Fixes: #78

- **feat: #78 フロントにユーザエンティティとリポジトリを追加**
- **feat: #78 ユーザボタンを追加**
- **feat: #78 既存のログインボタンを置換**
- **chore: #78 スマホビューではユーザ名を表示しない**
- **chore: #78 メールアドレスの情報をエンティティ型に予約しておく**
