### PR TITLE
ユーザテーブルにemailプロパティを追加

### DIFF
--- a/backend/src/features/tasks/domain/usecase.test.ts
+++ b/backend/src/features/tasks/domain/usecase.test.ts
@@ -17,6 +17,7 @@ describe('タスクの取得', () => {
     id: 'test_user_id',
     name: 'test user',
     auth0_user_id: 'auth0_test_user',
+    email: 'test@example.com',
   }
 
   beforeAll(async () => {

--- a/backend/src/features/tasks/infrastructure/repositoryImpl.test.ts
+++ b/backend/src/features/tasks/infrastructure/repositoryImpl.test.ts
@@ -17,6 +17,7 @@ describe('単一項目のCRUD', () => {
     id: ulid(),
     name: 'dummy',
     auth0_user_id: 'auth0|00000000',
+    email: 'test@example.com',
   }
 
   beforeAll(async () => {
@@ -106,6 +107,7 @@ describe('複数項目のリストとソート', () => {
     id: ulid(),
     name: 'dummy',
     auth0_user_id: 'auth0|00000000',
+    email: 'test@example.com',
   }
 
   beforeAll(async () => {

--- a/backend/src/features/tasks/presentation/route.test.ts
+++ b/backend/src/features/tasks/presentation/route.test.ts
@@ -21,6 +21,7 @@ describe('単一項目の操作', () => {
     id: 'test_user_id',
     name: 'test user',
     auth0_user_id: 'auth0_test_user',
+    email: 'test@example.com',
   }
 
   let token: string
@@ -216,6 +217,7 @@ describe('項目のリストアップ', () => {
       id: 'test_user_id',
       name: 'test user',
       auth0_user_id: auth0UserId,
+      email: 'test@example.com',
     })
 
     // ダミータスクを生成して流し込む

--- a/backend/src/features/users/domain/entity.ts
+++ b/backend/src/features/users/domain/entity.ts
@@ -7,6 +7,9 @@ export type UserData = {
 
   /** Auth0のユーザ識別子 (subクレーム) */
   auth0_user_id: string
+
+  /** メールアドレス */
+  email: string
 }
 
 export type User = UserData & {

--- a/backend/src/features/users/domain/usecase.ts
+++ b/backend/src/features/users/domain/usecase.ts
@@ -43,6 +43,7 @@ const createTentativeUser = (repository: UserRepository): UserUsecase['createTen
       id: ulid(),
       name: userInfo.nickname,
       auth0_user_id: userInfo.sub,
+      email: userInfo.email,
     }
     const registered = await repository.saveUser(newUser)
     return registered

--- a/backend/src/features/users/infrastructure/entity.ts
+++ b/backend/src/features/users/infrastructure/entity.ts
@@ -4,6 +4,7 @@ export const UserRecord = z.object({
   name: z.string(),
   auth0_user_id: z.string(),
   id: z.string(),
+  email: z.string(),
 })
 
 export type UserRecord = z.infer<typeof UserRecord>

--- a/backend/src/features/users/infrastructure/repositoryImpl.test.ts
+++ b/backend/src/features/users/infrastructure/repositoryImpl.test.ts
@@ -18,6 +18,7 @@ describe('単一項目のCRUD', () => {
       id: ulid(),
       name: 'test-user',
       auth0_user_id: 'auth0|0123456789',
+      email: 'test@example.com',
     }
     const inserted = await repo.saveUser(user)
     expect(user).toStrictEqual(inserted)
@@ -28,6 +29,7 @@ describe('単一項目のCRUD', () => {
       id: ulid(),
       name: 'test-user',
       auth0_user_id: 'auth0|0123456789',
+      email: 'test@example.com',
     }
     const { id } = await repo.saveUser(user)
 
@@ -40,6 +42,7 @@ describe('単一項目のCRUD', () => {
       id: ulid(),
       name: 'test-user',
       auth0_user_id: 'auth0|0123456789',
+      email: 'test@example.com',
     }
     const { auth0_user_id } = await repo.saveUser(user)
 
@@ -52,6 +55,7 @@ describe('単一項目のCRUD', () => {
       id: ulid(),
       name: 'test-user',
       auth0_user_id: 'auth0|0123456789',
+      email: 'test@example.com',
     }
     const stored = await repo.saveUser(user)
 

--- a/backend/src/features/users/infrastructure/repositoryImpl.ts
+++ b/backend/src/features/users/infrastructure/repositoryImpl.ts
@@ -23,16 +23,18 @@ const getUserByAuth0Id = (db: D1Database): UserRepository['getUserByAuth0Id'] =>
 
 const saveUser = (db: D1Database): UserRepository['saveUser'] => async (newUser: User) => {
   const stmt = `INSERT INTO users 
-    VALUES (?1,?2,?3)
+    VALUES (?1,?2,?3,?4)
     ON CONFLICT (id) DO UPDATE SET
         name = ?2,
-        auth0_user_id = ?3
+        auth0_user_id = ?3,
+        email = ?4
   `
 
   await db.prepare(stmt).bind(
     newUser.id,
     newUser.name,
     newUser.auth0_user_id,
+    newUser.email,
   ).run()
 
   return newUser

--- a/backend/src/features/users/presentation/route.test.ts
+++ b/backend/src/features/users/presentation/route.test.ts
@@ -15,6 +15,7 @@ describe('ユーザが存在する場合 (登録済みアカウントへのロ�
     id: 'test_user_id',
     name: 'test user',
     auth0_user_id: 'test_user',
+    email: 'test@example.com',
   }
 
   let token: string

--- a/backend/src/migrations/0004_add_email_column_to_users.sql
+++ b/backend/src/migrations/0004_add_email_column_to_users.sql
@@ -1,0 +1,5 @@
+-- Migration number: 0004 	 2025-04-14T10:59:58.484Z
+
+-- usersテーブルにemailカラムを追加する
+ALTER TABLE users
+ADD COLUMN email TEXT NOT NULL DEFAULT '';

--- a/frontend/src/repositories/userRepository.ts
+++ b/frontend/src/repositories/userRepository.ts
@@ -13,11 +13,7 @@ export const getCurrentUser = async (token: string): Promise<Result<User, Networ
       headers: { Authorization: `Bearer ${token}` },
     })
 
-    // TODO: #80 バックエンドからメールアドレスを取得できるようになったらオーバーライドを外す
-    return response.json().then(user => ok({
-      ...user,
-      email: 'mail@example.com',
-    }))
+    return response.json().then(user => ok(user))
   }
   catch (error) {
     const message = error instanceof Error ? error.message : 'unknown error'

--- a/hono_rpc_sample.code-workspace
+++ b/hono_rpc_sample.code-workspace
@@ -41,6 +41,12 @@
     },
     "[css]": {
       "editor.defaultFormatter": "vscode.css-language-features"
+    },
+    "github.copilot.enable": {
+      "*": false,
+      "plaintext": false,
+      "markdown": false,
+      "scminput": false
     }
   },
   "extensions": {


### PR DESCRIPTION
Fixes: #80

- **feat: #80 emailカラムを追加で生やすマイグレーションファイルを追加**
- **feat: #80 バックエンドのエンティティにemailプロパティを追加**
- **feat: #80 フロントエンドでユーザ情報を取得できるように**
